### PR TITLE
Fix render coalescing on iOS

### DIFF
--- a/Few-Mac/Mac.swift
+++ b/Few-Mac/Mac.swift
@@ -24,10 +24,3 @@ internal func markNeedsDisplay(view: ViewType) {
 internal func configureViewToAutoresize(view: ViewType) {
 	view.autoresizingMask = .ViewWidthSizable | .ViewHeightSizable
 }
-
-internal func atEndOfRunLoop(f: () -> ()) {
-    let observer = CFRunLoopObserverCreateWithHandler(kCFAllocatorDefault, CFRunLoopActivity.Exit.rawValue, 0, 0) { _, _ in
-        f()
-    }
-    CFRunLoopAddObserver(CFRunLoopGetMain(), observer, kCFRunLoopCommonModes)
-}

--- a/Few-iOS/iOS.swift
+++ b/Few-iOS/iOS.swift
@@ -20,5 +20,3 @@ internal func compareAndSetAlpha(view: UIView, alpha: CGFloat) {
 internal func configureViewToAutoresize(view: ViewType) {
 	view.autoresizingMask = .FlexibleWidth | .FlexibleHeight
 }
-
-internal let atEndOfRunLoop = NSOperationQueue.mainQueue().addOperationWithBlock

--- a/FewCore/Component.swift
+++ b/FewCore/Component.swift
@@ -234,9 +234,9 @@ public class Component<S>: Element {
 	}
 
 	final private func enqueueRender() {
-        if renderQueued { return }
-    
-        renderQueued = true
+		if renderQueued { return }
+
+		renderQueued = true
 
 		let observer = CFRunLoopObserverCreateWithHandler(kCFAllocatorDefault, CFRunLoopActivity.BeforeWaiting.rawValue, 0, 0) { _, activity in
 			self.renderQueued = false

--- a/FewCore/Component.swift
+++ b/FewCore/Component.swift
@@ -237,11 +237,12 @@ public class Component<S>: Element {
         if renderQueued { return }
     
         renderQueued = true
-        
-        atEndOfRunLoop {
-            self.renderQueued = false
-            self.render()
-        }
+
+		let observer = CFRunLoopObserverCreateWithHandler(kCFAllocatorDefault, CFRunLoopActivity.BeforeWaiting.rawValue, 0, 0) { _, activity in
+			self.renderQueued = false
+			self.render()
+		}
+		CFRunLoopAddObserver(CFRunLoopGetMain(), observer, kCFRunLoopCommonModes)
 	}
 
 	/// Get the current state of the component.


### PR DESCRIPTION
Render after CFRunLoopActivity.BeforeWaiting instead of on exit. I *think* this is more correct for both Mac and iOS.

/cc @coenert 