### PR TITLE
iOS: Restore NSStringDrawingOption.UsesFontLeading

### DIFF
--- a/Few-iOS/Label.swift
+++ b/Few-iOS/Label.swift
@@ -14,8 +14,7 @@ private let StringFudge = CGSize(width: 4, height: 0)
 private let ABigDimension: CGFloat = 10000
 
 internal func estimateStringSize(string: NSAttributedString, maxSize: CGSize = CGSize(width: ABigDimension, height: ABigDimension)) -> CGSize {
-	let options: NSStringDrawingOptions = NSStringDrawingOptions.UsesLineFragmentOrigin// | NSStringDrawingOptions.UsesFontLeading // Currently this is an enum(so it does not support multiple values). But this is fixed in iOS 8.3 SDK Beta 1
-	let rect = string.boundingRectWithSize(maxSize, options: options, context: nil)
+	let rect = string.boundingRectWithSize(maxSize, options: .UsesLineFragmentOrigin | .UsesFontLeading, context: nil)
 	let width = ceil(rect.size.width) + StringFudge.width
 	let height = ceil(rect.size.height) + StringFudge.height
 	return CGSize(width: width, height: height)


### PR DESCRIPTION
Hi there! I love your work, I think this needs to exist, and I'm hoping to lend a hand.

This one's simple – it restores the string measurement option that was broken on Swift 1.1.

