### PR TITLE
Make layout methods public

### DIFF
--- a/Few-Mac/Label.swift
+++ b/Few-Mac/Label.swift
@@ -62,7 +62,7 @@ public class Label: Element {
 		return field
 	}
 
-	internal override func assembleLayoutNode() -> Node {
+	public override func assembleLayoutNode() -> Node {
 		let childNodes = children.map { $0.assembleLayoutNode() }
 		return Node(size: frame.size, children: childNodes, direction: direction, margin: marginWithPlatformSpecificAdjustments, padding: paddingWithPlatformSpecificAdjustments, wrap: wrap, justification: justification, selfAlignment: selfAlignment, childAlignment: childAlignment, flex: flex) { w in
 			estimateStringSize(self.attributedString, maxSize: CGSize(width: w.isNaN ? ABigDimension : w, height: ABigDimension))

--- a/Few-iOS/Label.swift
+++ b/Few-iOS/Label.swift
@@ -59,7 +59,7 @@ public class Label: Element {
 		return label
 	}
 
-	internal override func assembleLayoutNode() -> Node {
+	public override func assembleLayoutNode() -> Node {
 		let childNodes = children.map { $0.assembleLayoutNode() }
 		return Node(size: frame.size, children: childNodes, direction: direction, margin: marginWithPlatformSpecificAdjustments, padding: paddingWithPlatformSpecificAdjustments, wrap: wrap, justification: justification, selfAlignment: selfAlignment, childAlignment: childAlignment, flex: flex) { w in
 			estimateStringSize(self.attributedString, maxSize: CGSize(width: w.isNaN ? ABigDimension : w, height: ABigDimension))

--- a/FewCore/Component.swift
+++ b/FewCore/Component.swift
@@ -329,13 +329,13 @@ public class Component<S>: Element {
 		}
 	}
 
-	internal override func assembleLayoutNode() -> Node {
+	public override func assembleLayoutNode() -> Node {
 		performInitialRenderIfNeeded()
 
 		return rootElement!.assembleLayoutNode()
 	}
 
-	override func applyLayout(layout: Layout) {
+	public override func applyLayout(layout: Layout) {
 		frame = layout.frame
 
 		rootElement?.applyLayout(layout)

--- a/FewCore/Element.swift
+++ b/FewCore/Element.swift
@@ -194,7 +194,7 @@ public class Element {
 	/// Derealize the element.
 	public func derealize() {}
 
-	internal func assembleLayoutNode() -> Node {
+	public func assembleLayoutNode() -> Node {
 		let childNodes = children.map { $0.assembleLayoutNode() }
 
 		return Node(size: frame.size, children: childNodes, direction: direction, margin: marginWithPlatformSpecificAdjustments, padding: paddingWithPlatformSpecificAdjustments, wrap: wrap, justification: justification, selfAlignment: selfAlignment, childAlignment: childAlignment, flex: flex)
@@ -220,7 +220,7 @@ public class Element {
 #endif
 	}
 
-	internal func applyLayout(layout: Layout) {
+	public func applyLayout(layout: Layout) {
 		frame = layout.frame
 
 		for (child, layout) in Zip2(children, layout.children) {


### PR DESCRIPTION
In my case this is useful when I'm rolling my own table view cells, so I can get the height of the element before I render it into a view. What good is an incredible UI library if the layout is so opaque?