### PR TITLE
iOS: Image View Tweaks

### DIFF
--- a/Few-iOS/Image.swift
+++ b/Few-iOS/Image.swift
@@ -11,10 +11,12 @@ import UIKit
 public class Image: Element {
 	public var image: UIImage?
 	public var scaling: UIViewContentMode
+	public var clipsToBounds: Bool
 	
-	public init(_ image: UIImage?, scaling: UIViewContentMode = .ScaleAspectFit) {
+	public init(_ image: UIImage?, scaling: UIViewContentMode = .ScaleAspectFit, clipsToBounds: Bool = false) {
 		self.image = image
 		self.scaling = scaling
+		self.clipsToBounds = clipsToBounds
 		
 		let size = image?.size ?? CGSize(width: Node.Undefined, height: Node.Undefined)
 		super.init(frame: CGRect(origin: CGPointZero, size: size))
@@ -33,6 +35,10 @@ public class Image: Element {
 			if view.image != image {
 				view.image = image
 			}
+			
+			if view.clipsToBounds != clipsToBounds {
+				view.clipsToBounds = clipsToBounds
+			}
 		}
 	}
 	
@@ -42,6 +48,7 @@ public class Image: Element {
 		view.hidden = hidden
 		view.image = image
 		view.contentMode = scaling
+		view.clipsToBounds = clipsToBounds
 		return view
 	}
 }

--- a/Few-iOS/Image.swift
+++ b/Few-iOS/Image.swift
@@ -41,6 +41,7 @@ public class Image: Element {
 		view.alpha = alpha
 		view.hidden = hidden
 		view.image = image
+		view.contentMode = scaling
 		return view
 	}
 }


### PR DESCRIPTION
- Make sure to set the initial content mode
- Make the `clipsToBounds` flag available. Pretty much any time you're using `.ScaleAspectFill` you want this set. It matters.