### PR TITLE
#nonamespace #noname #space #no #namespace #no #name #space

### DIFF
--- a/FewDemo-iOS/ViewController.swift
+++ b/FewDemo-iOS/ViewController.swift
@@ -88,7 +88,7 @@ enum ActiveComponent {
 	case Input
 }
 
-func renderApp(component: Few.Component<AppState>, state: AppState) -> Element {
+func renderApp(component: Component<AppState>, state: AppState) -> Element {
 	var contentComponent: Element!
 	switch state.activeComponent {
 	case .TableView:

--- a/FewDemo/AppDelegate.swift
+++ b/FewDemo/AppDelegate.swift
@@ -15,7 +15,7 @@ enum ActiveComponent {
 	case Counter
 }
 
-func renderApp(component: Few.Component<ActiveComponent>, state: ActiveComponent) -> Element {
+func renderApp(component: Component<ActiveComponent>, state: ActiveComponent) -> Element {
 	var contentComponent: Element!
 	switch state {
 	case .Demo:

--- a/FewDemo/Counter.swift
+++ b/FewDemo/Counter.swift
@@ -10,7 +10,7 @@ import AppKit
 import Few
 
 typealias Counter = Counter_<Int>
-class Counter_<LOL>: Few.Component<Int> {
+class Counter_<LOL>: Component<Int> {
 	init() {
 		super.init(initialState: 0)
 	}

--- a/FewDemo/CustomButton.swift
+++ b/FewDemo/CustomButton.swift
@@ -10,7 +10,7 @@ import Cocoa
 import Few
 
 typealias CustomButton = CustomButton_<Bool>
-class CustomButton_<LOL>: Few.Component<Bool> {
+class CustomButton_<LOL>: Component<Bool> {
 	var title: String
 	var action: () -> ()
 

--- a/FewDemo/Demo.swift
+++ b/FewDemo/Demo.swift
@@ -19,7 +19,7 @@ struct LoginState {
 	}
 }
 
-private func renderInput(component: Few.Component<LoginState>, label: String, secure: Bool, fn: (LoginState, String) -> LoginState) -> Element {
+private func renderInput(component: Component<LoginState>, label: String, secure: Bool, fn: (LoginState, String) -> LoginState) -> Element {
 	let action: String -> () = { str in
 		component.updateState { fn($0, str) }
 	}
@@ -49,7 +49,7 @@ struct ScrollViewState {
 	}
 }
 
-private func keyDown(event: NSEvent, component: Few.Component<ScrollViewState>) -> Bool {
+private func keyDown(event: NSEvent, component: Component<ScrollViewState>) -> Bool {
 	let characters = event.charactersIgnoringModifiers!.utf16
 	let firstCharacter = first(characters)
 	if firstCharacter == UInt16(NSDeleteCharacter) {
@@ -119,7 +119,7 @@ private func renderThingy(count: Int) -> Element {
 }
 
 typealias Demo = Demo_<()>
-class Demo_<LOL>: Few.Component<()> {
+class Demo_<LOL>: Component<()> {
 	init() {
 		super.init(initialState: ())
 	}

--- a/FewDemo/TemperatureConverter.swift
+++ b/FewDemo/TemperatureConverter.swift
@@ -49,7 +49,7 @@ private func parseFloat(str: String) -> CGFloat? {
 }
 
 typealias TemperatureConverter = TemperatureConverter_<ConverterState>
-class TemperatureConverter_<LOL>: Few.Component<ConverterState> {
+class TemperatureConverter_<LOL>: Component<ConverterState> {
 	init() {
 		super.init(initialState: ConverterState());
 	}


### PR DESCRIPTION
This was necessary in Xcode 6.2 but happily no longer is.