### PR TITLE
Public trampoline makes custom elements easier

### DIFF
--- a/FewCore/TargetActionTrampoline.swift
+++ b/FewCore/TargetActionTrampoline.swift
@@ -8,23 +8,23 @@
 
 import Foundation
 
-internal class TargetActionTrampoline: NSObject {
-	internal var action: (() -> ())?
+public class TargetActionTrampoline: NSObject {
+	public var action: (() -> ())?
 
-	internal let selector = Selector("performAction:")
+	public let selector = Selector("performAction:")
 
-	internal func performAction(sender: AnyObject?) {
+	public func performAction(sender: AnyObject?) {
 		action?()
 	}
 }
 
-internal class TargetActionTrampolineWithSender<T: AnyObject> {
-	internal var target = TargetActionTrampolineProxy()
-	internal var selector: Selector {
+public class TargetActionTrampolineWithSender<T: AnyObject> {
+	public var target = TargetActionTrampolineProxy()
+	public var selector: Selector {
 		return target.selector
 	}
 
-	internal var action: (T -> ())? {
+	public var action: (T -> ())? {
 		get {
 			return target.action
 		}
@@ -38,12 +38,12 @@ internal class TargetActionTrampolineWithSender<T: AnyObject> {
 	}
 }
 
-internal class TargetActionTrampolineProxy: NSObject {
-	internal var action: (AnyObject? -> ())?
+public class TargetActionTrampolineProxy: NSObject {
+	public var action: (AnyObject? -> ())?
 
 	private let selector = Selector("performAction:")
 
-	internal func performAction(sender: AnyObject?) {
+	public func performAction(sender: AnyObject?) {
 		action?(sender)
 	}
 }


### PR DESCRIPTION
I would like to propose making the trampolines public for anybody to bounce on :tada: 

What this allows us to do is make custom components subclassed from `Few.Element` that also want to have target actions. An example could be a super duper stylize custom button that will get reused through an app.

## SuperDuperStylizedCustomButton.swift
```swift
public class SuperDuperStylizedCustomButton: Few.Element {
	
	internal var trampoline = TargetActionTrampoline()
	var title: String?
	
	public init(title: String, action: () -> () = { }) {
		self.title = title
		trampoline.action = action
		super.init(frame: CGRect(x: 0, y: 0, width: 50, height: 23))
	}
	
	// MARK: Element
	
	public override func applyDiff(old: Element, realizedSelf: RealizedElement?) {
		super.applyDiff(old, realizedSelf: realizedSelf)
		
		if let button = realizedSelf?.view as? UIButton {
			if let oldButton = old as? CometButton {
				let newTrampoline = oldButton.trampoline
				newTrampoline.action = trampoline.action // Make sure the newest action is used
				trampoline = newTrampoline
			}
			
			if title != button.titleForState(.Normal) {
				button.setTitle(title, forState: .Normal)
			}
		}
	}
	
	public override func createView() -> ViewType {
		let button = UIButton(frame: CGRectZero)
		button.setTitle(title, forState: .Normal)
		button.setTitleColor(UIColor.blackColor(), forState: .Normal)
		
		// WOAH, look at this custom stuff
		button.backgroundColor = UIColor.blueColor()
		button.setTitleColor(UIColor.whiteColor(), forState: .Normal)
		button.setTitleColor(UIColor.lightTextColor(), forState: .Highlighted)
		
		// NO WAY, even more custom stuff
		button.layer.cornerRadius = 2
		button.layer.borderColor = UIColor.darkGrayColor().CGColor
		button.layer.borderWidth = 1
		
		// NICE! It sure is handy I can use this trampoline ;)
		button.addTarget(trampoline, action: trampoline.selector, forControlEvents: .TouchUpInside)

		return button
	}
}
```